### PR TITLE
Add new stats functions to traci_functions.py

### DIFF
--- a/src/sumo_experiments/plot/results_plotter.py
+++ b/src/sumo_experiments/plot/results_plotter.py
@@ -8,6 +8,8 @@ class ResultsPlotter:
     """
     The DetectorBuilder class can be used to plot the results of a series of experiments. Experiments results must be
     saved in a CSV file, with the 'export_results_to_csv' function, to be read by the plotter.
+
+    deprecated:: 2.0.0
     """
 
     def __init__(self, file, sampling_rate, max_ticks, save_folder):

--- a/src/sumo_experiments/traci_util/traci_functions.py
+++ b/src/sumo_experiments/traci_util/traci_functions.py
@@ -10,15 +10,16 @@ def get_nb_vehicles(config):
     :return: A dictionary with number of vehicle value
     :rtype: dict
     """
-    vehicles = traci.vehicle.getIDList()
+    count = traci.vehicle.getIDCount()
     res = {
-        'nb_running_vehicles': len(vehicles)
+        'nb_running_vehicles': count
     }
     return res
 
+
 def get_acceleration_data(config):
     """
-    Return the mean and sum of all running vehicles acceleration on the network.
+    Return acceleration data for all running vehicles on the network.
     :param config: Configuration data for the function
     :type config: dict
     :return: A dictionary with acceleration values
@@ -29,14 +30,18 @@ def get_acceleration_data(config):
     for vehicle in vehicles:
         accels.append(traci.vehicle.getAcceleration(vehicle))
     res = {
-        'mean_acceleration': np.mean(accels)
+        'mean_acceleration': np.mean(accels) if len(accels) > 0 else np.nan,
+        'sum_acceleration': np.sum(accels) if len(accels) > 0 else np.nan,
+        'max_acceleration': np.max(accels) if len(accels) > 0 else np.nan,
+        'min_acceleration': np.min(accels) if len(accels) > 0 else np.nan,
+        'std_dev_acceleration': np.std(accels) if len(accels) > 0 else np.nan
     }
     return res
 
 
 def get_speed_data(config):
     """
-    Return the mean and sum of all running vehicles speed on the network.
+    Return speed data for all running vehicles on the network.
     :param config: Configuration data for the function
     :type config: dict
     :return: A dictionary with speed values
@@ -47,6 +52,98 @@ def get_speed_data(config):
     for vehicle in vehicles:
         speeds.append(traci.vehicle.getSpeed(vehicle))
     res = {
-        'mean_speed': np.mean(speeds)
+        'mean_speed': np.mean(speeds) if len(speeds) > 0 else np.nan,
+        'sum_speed': np.sum(speeds) if len(speeds) > 0 else np.nan,
+        'max_speed': np.max(speeds) if len(speeds) > 0 else np.nan,
+        'min_speed': np.min(speeds) if len(speeds) > 0 else np.nan,
+        'std_dev_speed': np.std(speeds) if len(speeds) > 0 else np.nan
+    }
+    return res
+
+
+def get_co2_emissions_data(config):
+    """
+    Return CO2 emissions data for all running vehicles on the network.
+    :param config: Configuration data for the function
+    :type config: dict
+    :return: A dictionary with CO2 values
+    :rtype: dict
+    """
+    emissions = []
+    vehicles = traci.vehicle.getIDList()
+    for vehicle in vehicles:
+        emissions.append(traci.vehicle.getCO2Emission(vehicle))
+    res = {
+        'mean_co2_emissions': np.mean(emissions) if len(emissions) > 0 else np.nan,
+        'sum_co2_emissions': np.sum(emissions) if len(emissions) > 0 else np.nan,
+        'max_co2_emissions': np.max(emissions) if len(emissions) > 0 else np.nan,
+        'min_co2_emissions': np.min(emissions) if len(emissions) > 0 else np.nan,
+        'std_dev_co2_emissions': np.std(emissions) if len(emissions) > 0 else np.nan
+    }
+    return res
+
+
+def get_co_emissions_data(config):
+    """
+    Return CO emissions data for all running vehicles on the network.
+    :param config: Configuration data for the function
+    :type config: dict
+    :return: A dictionary with CO values
+    :rtype: dict
+    """
+    emissions = []
+    vehicles = traci.vehicle.getIDList()
+    for vehicle in vehicles:
+        emissions.append(traci.vehicle.getCOEmission(vehicle))
+    res = {
+        'mean_co_emissions': np.mean(emissions) if len(emissions) > 0 else np.nan,
+        'sum_co_emissions': np.sum(emissions) if len(emissions) > 0 else np.nan,
+        'max_co_emissions': np.max(emissions) if len(emissions) > 0 else np.nan,
+        'min_co_emissions': np.min(emissions) if len(emissions) > 0 else np.nan,
+        'std_dev_co_emissions': np.std(emissions) if len(emissions) > 0 else np.nan
+    }
+    return res
+
+
+def get_nox_emissions_data(config):
+    """
+    Return NOx emissions data for all running vehicles on the network.
+    :param config: Configuration data for the function
+    :type config: dict
+    :return: A dictionary with NOx values
+    :rtype: dict
+    """
+    emissions = []
+    vehicles = traci.vehicle.getIDList()
+    for vehicle in vehicles:
+        emissions.append(traci.vehicle.getNOxEmission(vehicle))
+    res = {
+        'mean_nox_emissions': np.mean(emissions) if len(emissions) > 0 else np.nan,
+        'sum_nox_emissions': np.sum(emissions) if len(emissions) > 0 else np.nan,
+        'max_nox_emissions': np.max(emissions) if len(emissions) > 0 else np.nan,
+        'min_nox_emissions': np.min(emissions) if len(emissions) > 0 else np.nan,
+        'std_dev_nox_emissions': np.std(emissions) if len(emissions) > 0 else np.nan
+    }
+    return res
+
+
+def get_fuel_consumption_data(config):
+    """
+    Return fuel consumption data for all running vehicles on the network.
+    :param config: Configuration data for the function
+    :type config: dict
+    :return: A dictionary with speed values
+    :rtype: dict
+    """
+    fuel_consumption = []
+    vehicles = traci.vehicle.getIDList()
+    for vehicle in vehicles:
+        fuel_consumption.append(traci.vehicle.getCO2Emission(vehicle))
+    res = {
+        'mean_fuel_consumption': np.mean(fuel_consumption) if len(fuel_consumption) > 0 else np.nan,
+        'sum_fuel_consumption': np.sum(fuel_consumption) if len(fuel_consumption) > 0 else np.nan,
+        'max_fuel_consumption': np.max(fuel_consumption) if len(fuel_consumption) > 0 else np.nan,
+        'min_fuel_consumption': np.min(fuel_consumption) if len(fuel_consumption) > 0 else np.nan,
+        'std_dev_fuel_consumption': np.std(fuel_consumption) if len(fuel_consumption) > 0 else np.nan
     }
     return res


### PR DESCRIPTION
Add new traci stats functions to get CO2, CO and NOx emissions, and fuel consumption.
Add new stats for each functions (mean, min, max, sum, standard dev).
Add the mean_travel_time and exiting vehicles to default data for TraciWrapper.