### PR TITLE
Fix traci training bug: sumo pending insertion vehicles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["hatchling"]
 
 [project]
 name = "sumo-experiments"
-version = "5.8.1"
+version = "5.8.3"
 authors = [
     { name="Jules Bompard", email="jules.bompard.etu@univ-lille.fr" },
     { name="Antoine Nongaillard", email="antoine.nongaillard@univ-lille.fr"},

--- a/src/sumo_experiments/preset_networks/line_network.py
+++ b/src/sumo_experiments/preset_networks/line_network.py
@@ -594,7 +594,7 @@ class LineNetwork(ArtificialNetwork):
                 2: {
                     'boolean': [f'b_n{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f'b_s{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)],
                     'saturation': [f's_n{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f's_s{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)],
-                    'numerical': [f'n_c{i}n{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f'n_c{i}s{i}_{n_lane}' for n_lane in range(nb_lanes_minor)],
+                    'numerical': [f'n_n{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f'n_s{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)],
                     'exit': [f'e_n{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f'e_s{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f'e_c{i}c{i-1}_{n_lane}' for n_lane in range(nb_lanes_main)] + [f'e_c{i}c{i+1}_{n_lane}' for n_lane in range(nb_lanes_main)]
                 },
             }

--- a/src/sumo_experiments/preset_networks/line_network.py
+++ b/src/sumo_experiments/preset_networks/line_network.py
@@ -589,13 +589,13 @@ class LineNetwork(ArtificialNetwork):
                     'boolean': [f'b_c{i-1}c{i}_{n_lane}' for n_lane in range(nb_lanes_main)] + [f'b_c{i+1}c{i}_{n_lane}' for n_lane in range(nb_lanes_main)],
                     'saturation': [f's_c{i-1}c{i}_{n_lane}' for n_lane in range(nb_lanes_main)] + [f's_c{i+1}c{i}_{n_lane}' for n_lane in range(nb_lanes_main)],
                     'numerical': [f'n_c{i-1}c{i}_{n_lane}' for n_lane in range(nb_lanes_main)] + [f'n_c{i+1}c{i}_{n_lane}' for n_lane in range(nb_lanes_main)],
-                    'exit': [f'e_c{i}c{i-1}_{n_lane}' for n_lane in range(nb_lanes_main)] + [f'e_c{i}c{i+1}_{n_lane}' for n_lane in range(nb_lanes_main)] + [f'e_n{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f'e_s{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)]
+                    'exit': [f'e_c{i}c{i-1}_{n_lane}' for n_lane in range(nb_lanes_main)] + [f'e_c{i}c{i+1}_{n_lane}' for n_lane in range(nb_lanes_main)] + [f'e_c{i}n{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f'e_c{i}s{i}_{n_lane}' for n_lane in range(nb_lanes_minor)]
                 },
                 2: {
                     'boolean': [f'b_n{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f'b_s{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)],
                     'saturation': [f's_n{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f's_s{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)],
                     'numerical': [f'n_n{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f'n_s{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)],
-                    'exit': [f'e_n{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f'e_s{i}c{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f'e_c{i}c{i-1}_{n_lane}' for n_lane in range(nb_lanes_main)] + [f'e_c{i}c{i+1}_{n_lane}' for n_lane in range(nb_lanes_main)]
+                    'exit': [f'e_c{i}n{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f'e_c{i}s{i}_{n_lane}' for n_lane in range(nb_lanes_minor)] + [f'e_c{i}c{i-1}_{n_lane}' for n_lane in range(nb_lanes_main)] + [f'e_c{i}c{i+1}_{n_lane}' for n_lane in range(nb_lanes_main)]
                 },
             }
             self.TLS_DETECTORS[f'c{i}'] = detectors

--- a/src/sumo_experiments/strategies/transformerDQN_strategy.py
+++ b/src/sumo_experiments/strategies/transformerDQN_strategy.py
@@ -55,13 +55,18 @@ class TransformerDQNStrategy(DQNStrategy):
         return {tl_id: cast_fn(value) for tl_id in self.network.TLS_DETECTORS}
 
     def _estimate_axis_scale(self, values):
+        # A degenerate axis (all TLS share one coordinate, e.g. a collinear line
+        # network on the y axis) has no spread to infer a grid step from. That is
+        # fine: every delta on that axis is 0, so 0 / scale == 0 regardless of the
+        # scale value. Return a harmless unit scale instead of raising, so line
+        # networks work while grid networks still get a real per-axis scale.
         uniq = sorted({round(float(v), 6) for v in values})
         if len(uniq) < 2:
-            raise ValueError("Relative position encoding requires at least two distinct coordinates per axis.")
+            return 1.0
         diffs = [abs(uniq[i + 1] - uniq[i]) for i in range(len(uniq) - 1)]
         diffs = [d for d in diffs if d > 1e-6]
         if not diffs:
-            raise ValueError("Unable to infer coordinate grid scale from TLS junction positions.")
+            return 1.0
         return float(np.median(diffs))
 
     def _resolve_network_path(self):

--- a/src/sumo_experiments/traci_util/traci_wrapper.py
+++ b/src/sumo_experiments/traci_util/traci_wrapper.py
@@ -298,6 +298,10 @@ class TraciWrapper:
                 if reset_this_step:
                     for vehicle_id in traci.vehicle.getIDList():
                         traci.vehicle.remove(vehicle_id)
+                    # Drain the pending insertion backlog too: getIDList() returns
+                    # only running vehicles, so undeparted vehicles would otherwise
+                    # accumulate forever and make every simulationStep O(backlog).
+                    traci.simulation.clearPending()
                     running_vehicles.clear()
                     if self.scale_factors is not None:
                         factor = self.scale_factors[deletion_index]


### PR DESCRIPTION
Fixes #35. Sumo has vehicles pending insertion, but the reset does not clear these vehicles from the queue, building up in memory and slowing down the simulation during training. This does not affect evaluation experiments.

Also minor bugfix in linenetwork is also shipped with this PR